### PR TITLE
Fix memory leak due to missing dispose

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -128,21 +128,23 @@ namespace PDFConverter
 
             string filename = filePaths[0];
 
-            PdfDocument doc = PdfDocument.Load(filename);
-            List<System.Drawing.Image> images = new List<System.Drawing.Image>();
-
-            //Get an image for each page
-            for (int i = 0; i < doc.PageCount; i++)
+            using (PdfDocument doc = PdfDocument.Load(filename))
             {
-                System.Drawing.Image img = doc.Render(i, (int)doc.PageSizes[i].Width, (int)doc.PageSizes[i].Height, 150, 150, PdfRenderFlags.CorrectFromDpi);
-                images.Add(img);
-            }
+                List<System.Drawing.Image> images = new List<System.Drawing.Image>();
 
-            //Keep hold of the images related to each pdf
-            if (images != null && images.Count > 0)
-            {
-                string name = Path.GetFileNameWithoutExtension(filename);
-                pdfToSave = new KeyValuePair<string, List<System.Drawing.Image>>(name, images);
+                //Get an image for each page
+                for (int i = 0; i < doc.PageCount; i++)
+                {
+                    System.Drawing.Image img = doc.Render(i, (int)doc.PageSizes[i].Width, (int)doc.PageSizes[i].Height, 150, 150, PdfRenderFlags.CorrectFromDpi);
+                    images.Add(img);
+                }
+
+                //Keep hold of the images related to each pdf
+                if (images != null && images.Count > 0)
+                {
+                    string name = Path.GetFileNameWithoutExtension(filename);
+                    pdfToSave = new KeyValuePair<string, List<System.Drawing.Image>>(name, images);
+                }
             }
 
             return pdfToSave;


### PR DESCRIPTION
pdfium (PdfDocument) is probably using a lot of unmanaged stuff, so it's essential to dispose it after using it.

Fixes #1 

Before:
![before](https://user-images.githubusercontent.com/7165033/67437279-c3f3c600-f5f0-11e9-8833-8faf3f7cb37e.png)

After:
![after](https://user-images.githubusercontent.com/7165033/67437290-cbb36a80-f5f0-11e9-9ff9-2d1ddff3b0da.png)
